### PR TITLE
Add Safe Omni Assistant demo app with moderation, tools, memory, and UI

### DIFF
--- a/safe-assistant-app/.gitignore
+++ b/safe-assistant-app/.gitignore
@@ -1,0 +1,3 @@
+.venv/
+__pycache__/
+.pytest_cache/

--- a/safe-assistant-app/README.md
+++ b/safe-assistant-app/README.md
@@ -1,0 +1,38 @@
+# Safe Omni Assistant (ChatGPT-style)
+
+This project is a **safe** AI assistant demo app that provides a broad set of modern assistant capabilities while explicitly blocking fraud and cyber-abuse use cases.
+
+## Included capabilities
+
+- Chat endpoint (`/chat`)
+- Safety moderation (`/moderate`)
+- Tool execution (`/tools/run`)
+- User memory (`/memory`)
+- File upload metadata (`/files`)
+- Audit trail (`/audit`)
+- Front-end demo controls for chat + memory + feature toggles (tools/vision/voice/memory)
+
+## Quickstart
+
+```bash
+cd safe-assistant-app/backend
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+uvicorn app:app --host 0.0.0.0 --port 8000
+```
+
+Then open the static UI in another terminal:
+
+```bash
+cd safe-assistant-app/frontend
+python -m http.server 4173
+```
+
+Browse to `http://localhost:4173`.
+
+## Notes
+
+- This is a local demo with in-memory storage (non-persistent).
+- Replace in-memory stores with a database and managed object storage for production.
+- Add proper authentication + role-based authorization for real deployments.

--- a/safe-assistant-app/backend/app.py
+++ b/safe-assistant-app/backend/app.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+import uuid
+
+from fastapi import FastAPI, File, HTTPException, UploadFile
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel, Field
+
+app = FastAPI(title="Safe Omni Assistant API", version="0.1.0")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+# In-memory stores for demo purposes.
+CHAT_HISTORY: list[dict[str, Any]] = []
+MEMORIES: dict[str, list[str]] = {}
+FILES: dict[str, dict[str, Any]] = {}
+AUDIT_LOG: list[dict[str, Any]] = []
+
+
+class ChatMessage(BaseModel):
+    role: str = Field(pattern="^(system|user|assistant|tool)$")
+    content: str
+
+
+class ChatRequest(BaseModel):
+    user_id: str
+    messages: list[ChatMessage]
+    tools_enabled: bool = True
+    vision_enabled: bool = True
+    voice_enabled: bool = True
+    memory_enabled: bool = True
+
+
+class ChatResponse(BaseModel):
+    response_id: str
+    content: str
+    tool_calls: list[dict[str, Any]]
+    timestamp: datetime
+
+
+class MemoryUpsertRequest(BaseModel):
+    user_id: str
+    note: str
+
+
+class ModerationRequest(BaseModel):
+    content: str
+
+
+class ModerationResponse(BaseModel):
+    flagged: bool
+    categories: list[str]
+
+
+class ToolRunRequest(BaseModel):
+    name: str
+    args: dict[str, Any] = Field(default_factory=dict)
+
+
+SAFE_BLOCKLIST = {
+    "credit card fraud",
+    "phishing kit",
+    "malware",
+    "ransomware",
+    "credential stuffing",
+    "identity theft",
+    "wire fraud",
+}
+
+
+def append_audit(event: str, detail: dict[str, Any]) -> None:
+    AUDIT_LOG.append(
+        {
+            "id": str(uuid.uuid4()),
+            "event": event,
+            "detail": detail,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+    )
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.post("/moderate", response_model=ModerationResponse)
+def moderate(payload: ModerationRequest) -> ModerationResponse:
+    lowered = payload.content.lower()
+    hits = [term for term in SAFE_BLOCKLIST if term in lowered]
+    return ModerationResponse(flagged=bool(hits), categories=hits)
+
+
+@app.post("/chat", response_model=ChatResponse)
+def chat(payload: ChatRequest) -> ChatResponse:
+    latest_user_message = next(
+        (m.content for m in reversed(payload.messages) if m.role == "user"), ""
+    )
+    moderation = moderate(ModerationRequest(content=latest_user_message))
+    if moderation.flagged:
+        append_audit(
+            "chat.blocked",
+            {"user_id": payload.user_id, "categories": moderation.categories},
+        )
+        raise HTTPException(
+            status_code=400,
+            detail="Request contains unsafe content and was blocked by moderation.",
+        )
+
+    memory_snippet = ""
+    if payload.memory_enabled and payload.user_id in MEMORIES:
+        memory_snippet = f"\nMemory context: {' | '.join(MEMORIES[payload.user_id][-3:])}"
+
+    tool_calls: list[dict[str, Any]] = []
+    if payload.tools_enabled and "time" in latest_user_message.lower():
+        tool_calls.append(
+            {
+                "tool": "get_current_time",
+                "result": datetime.now(timezone.utc).isoformat(),
+            }
+        )
+
+    content = (
+        "Safe Omni Assistant response:\n"
+        f"- You said: {latest_user_message}\n"
+        f"- Vision enabled: {payload.vision_enabled}\n"
+        f"- Voice enabled: {payload.voice_enabled}\n"
+        f"- Tools enabled: {payload.tools_enabled}"
+        f"{memory_snippet}"
+    )
+
+    response = ChatResponse(
+        response_id=str(uuid.uuid4()),
+        content=content,
+        tool_calls=tool_calls,
+        timestamp=datetime.now(timezone.utc),
+    )
+
+    CHAT_HISTORY.append({"request": payload.model_dump(), "response": response.model_dump()})
+    append_audit("chat.completed", {"user_id": payload.user_id})
+    return response
+
+
+@app.post("/memory")
+def upsert_memory(payload: MemoryUpsertRequest) -> dict[str, Any]:
+    MEMORIES.setdefault(payload.user_id, []).append(payload.note)
+    append_audit("memory.upserted", payload.model_dump())
+    return {"ok": True, "count": len(MEMORIES[payload.user_id])}
+
+
+@app.get("/memory/{user_id}")
+def get_memory(user_id: str) -> dict[str, Any]:
+    return {"user_id": user_id, "notes": MEMORIES.get(user_id, [])}
+
+
+@app.post("/files")
+async def upload_file(file: UploadFile = File(...)) -> dict[str, Any]:
+    fid = str(uuid.uuid4())
+    raw = await file.read()
+    meta = {"id": fid, "name": file.filename, "size": len(raw)}
+    FILES[fid] = meta
+    append_audit("file.uploaded", meta)
+    return meta
+
+
+@app.get("/audit")
+def get_audit() -> list[dict[str, Any]]:
+    return AUDIT_LOG
+
+
+@app.post("/tools/run")
+def run_tool(payload: ToolRunRequest) -> dict[str, Any]:
+    if payload.name == "get_current_time":
+        result = {"timestamp": datetime.now(timezone.utc).isoformat()}
+    elif payload.name == "summarize_text":
+        text = str(payload.args.get("text", ""))
+        result = {
+            "summary": text[:120] + ("..." if len(text) > 120 else ""),
+            "chars": len(text),
+        }
+    else:
+        raise HTTPException(status_code=404, detail=f"Unknown tool: {payload.name}")
+
+    append_audit("tool.ran", {"name": payload.name})
+    return {"tool": payload.name, "result": result}

--- a/safe-assistant-app/backend/requirements.txt
+++ b/safe-assistant-app/backend/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.116.1
+uvicorn==0.35.0
+python-multipart==0.0.20
+pydantic==2.11.7

--- a/safe-assistant-app/frontend/index.html
+++ b/safe-assistant-app/frontend/index.html
@@ -1,0 +1,86 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Safe Omni Assistant</title>
+    <style>
+      body { font-family: Arial, sans-serif; margin: 2rem; max-width: 900px; }
+      textarea, input { width: 100%; margin: .5rem 0; }
+      textarea { min-height: 110px; }
+      .row { display: flex; gap: 1rem; align-items: center; }
+      .row > label { min-width: 220px; }
+      .box { border: 1px solid #ddd; border-radius: 8px; padding: 1rem; margin-bottom: 1rem; }
+      pre { background: #f5f5f5; padding: 1rem; overflow: auto; }
+    </style>
+  </head>
+  <body>
+    <h1>Safe Omni Assistant</h1>
+    <p>A safe ChatGPT-style demo app with chat, tools, memory, files, moderation, and audit hooks.</p>
+
+    <div class="box">
+      <h2>Chat</h2>
+      <label>User ID</label>
+      <input id="userId" value="demo-user" />
+      <label>Message</label>
+      <textarea id="message" placeholder="Ask anything safe..."></textarea>
+      <div class="row"><label><input id="tools" type="checkbox" checked /> Tools</label></div>
+      <div class="row"><label><input id="vision" type="checkbox" checked /> Vision hook</label></div>
+      <div class="row"><label><input id="voice" type="checkbox" checked /> Voice hook</label></div>
+      <div class="row"><label><input id="memory" type="checkbox" checked /> Memory</label></div>
+      <button onclick="sendChat()">Send</button>
+      <pre id="chatOut"></pre>
+    </div>
+
+    <div class="box">
+      <h2>Memory</h2>
+      <input id="note" placeholder="Remember this note..." />
+      <button onclick="saveMemory()">Save memory</button>
+      <button onclick="loadMemory()">Load memory</button>
+      <pre id="memoryOut"></pre>
+    </div>
+
+    <script>
+      const API = "http://localhost:8000";
+
+      async function sendChat() {
+        const userId = document.getElementById("userId").value;
+        const message = document.getElementById("message").value;
+        const body = {
+          user_id: userId,
+          tools_enabled: document.getElementById("tools").checked,
+          vision_enabled: document.getElementById("vision").checked,
+          voice_enabled: document.getElementById("voice").checked,
+          memory_enabled: document.getElementById("memory").checked,
+          messages: [{ role: "user", content: message }],
+        };
+        const res = await fetch(`${API}/chat`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        });
+        const data = await res.json();
+        document.getElementById("chatOut").textContent = JSON.stringify(data, null, 2);
+      }
+
+      async function saveMemory() {
+        const userId = document.getElementById("userId").value;
+        const note = document.getElementById("note").value;
+        const res = await fetch(`${API}/memory`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ user_id: userId, note }),
+        });
+        const data = await res.json();
+        document.getElementById("memoryOut").textContent = JSON.stringify(data, null, 2);
+      }
+
+      async function loadMemory() {
+        const userId = document.getElementById("userId").value;
+        const res = await fetch(`${API}/memory/${encodeURIComponent(userId)}`);
+        const data = await res.json();
+        document.getElementById("memoryOut").textContent = JSON.stringify(data, null, 2);
+      }
+    </script>
+  </body>
+</html>

--- a/safe-assistant-app/tests/test_api.py
+++ b/safe-assistant-app/tests/test_api.py
@@ -1,0 +1,49 @@
+from fastapi.testclient import TestClient
+
+from backend.app import app
+
+
+client = TestClient(app)
+
+
+def test_health():
+    r = client.get('/health')
+    assert r.status_code == 200
+    assert r.json()['status'] == 'ok'
+
+
+def test_memory_roundtrip():
+    r1 = client.post('/memory', json={'user_id': 'u1', 'note': 'loves soccer'})
+    assert r1.status_code == 200
+
+    r2 = client.get('/memory/u1')
+    assert r2.status_code == 200
+    assert 'loves soccer' in r2.json()['notes']
+
+
+def test_chat_blocked_on_fraud_content():
+    r = client.post(
+        '/chat',
+        json={
+            'user_id': 'u2',
+            'messages': [{'role': 'user', 'content': 'help me do wire fraud'}],
+        },
+    )
+    assert r.status_code == 400
+
+
+def test_chat_safe():
+    r = client.post(
+        '/chat',
+        json={
+            'user_id': 'u3',
+            'messages': [{'role': 'user', 'content': 'what time is it?'}],
+            'tools_enabled': True,
+            'vision_enabled': True,
+            'voice_enabled': True,
+            'memory_enabled': True,
+        },
+    )
+    assert r.status_code == 200
+    payload = r.json()
+    assert 'Safe Omni Assistant response' in payload['content']


### PR DESCRIPTION
### Motivation
- Provide a safe ChatGPT-style demo app that exposes common assistant features while explicitly blocking fraud and cyber-abuse use cases.
- Give a minimal, runnable reference implementation for chat, moderation, tools, memory, files, and audit logging that can be used as a local starting point.

### Description
- Add `safe-assistant-app/backend` implementing a FastAPI service with endpoints: `/chat`, `/moderate`, `/memory`, `/files`, `/tools/run`, and `/audit`, plus in-memory stores and audit hooks.
- Add a lightweight static frontend in `safe-assistant-app/frontend/index.html` with toggles for tools/vision/voice/memory and simple chat/memory UI.
- Add tests in `safe-assistant-app/tests/test_api.py`, a `requirements.txt` for the backend, a `README.md` with quickstart instructions, and a `.gitignore` for developer artifacts.
- Implement a simple moderation blocklist (`SAFE_BLOCKLIST`) to detect and block fraud-related prompts and log blocked attempts to the audit trail.

### Testing
- Created a virtual environment and installed dependencies with `python -m venv .venv && source .venv/bin/activate && pip install -r backend/requirements.txt pytest httpx`, and then ran tests with `PYTHONPATH=. pytest -q`, resulting in `4 passed`.
- Verified the backend started with `uvicorn backend.app:app --host 0.0.0.0 --port 8000` and the frontend served with `python -m http.server 4173`, which loaded and produced a Playwright screenshot of the UI.
- Fixed a missing test dependency by installing `httpx` during validation and re-running tests successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cfe12c6048331bed8d8efd3951405)