### PR TITLE
Add Linux auto-setup script and detailed README interpretation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,131 @@
+# Linux Auto Setup
+
+This repository includes an automated Linux bootstrap script:
+
+- `scripts/setup-linux-auto.sh`
+
+## Quick usage
+
+```bash
+sudo ./scripts/setup-linux-auto.sh
+```
+
+Override log file path if needed:
+
+```bash
+sudo LOG_FILE=/tmp/linux-setup.log ./scripts/setup-linux-auto.sh
+```
+
+---
+
+## Script interpretation (`scripts/setup-linux-auto.sh`)
+
+This section explains what each part of the script does.
+
+### 1) Safety and shell behavior
+
+- `#!/usr/bin/env bash`: uses Bash explicitly.
+- `set -euo pipefail`:
+  - `-e`: stop on command errors.
+  - `-u`: treat unset variables as errors.
+  - `-o pipefail`: fail pipelines if any command in them fails.
+
+Why it matters: this makes setup automation safer and less likely to silently continue in a broken state.
+
+### 2) Configuration values
+
+- `LOG_FILE="${LOG_FILE:-/var/log/linux-auto-setup.log}"`
+  - Uses `/var/log/linux-auto-setup.log` by default.
+  - Lets callers override path with `LOG_FILE=...`.
+- `PACKAGES=(...)`
+  - Defines baseline tools and security packages to install.
+  - Includes: `curl`, `wget`, `git`, `vim`, `htop`, `unzip`, `ca-certificates`, `gnupg`, `lsb-release`, `ufw`, `fail2ban`.
+
+### 3) Logging helpers
+
+- `info()` and `warn()` format status messages with tags.
+- The script creates/touches the log file and redirects all stdout/stderr through `tee` so output is visible and persisted.
+
+### 4) Root requirement
+
+- Checks `EUID` and exits unless run as root.
+- This is required because package installation, service control, and firewall changes need elevated privileges.
+
+### 5) Package manager detection
+
+Function: `detect_pm()`
+
+Order of detection:
+1. `apt-get` → returns `apt`
+2. `dnf` → returns `dnf`
+3. `pacman` → returns `pacman`
+4. Otherwise → `unknown`
+
+This allows one script to support Debian/Ubuntu, Fedora, and Arch-based systems.
+
+### 6) Package installation flow
+
+Function: `install_packages(pm)`
+
+- For `apt`:
+  - runs `apt-get update`
+  - installs package list with non-interactive mode.
+- For `dnf`:
+  - installs package list with `dnf install -y`.
+- For `pacman`:
+  - refreshes DB and installs only missing packages via `--needed`.
+- For unsupported PM:
+  - logs warning and skips installation.
+
+### 7) Systemd service handling
+
+Function: `enable_service_if_exists(service)`
+
+- Checks whether a service unit exists in `systemctl list-unit-files`.
+- If present, enables and starts it.
+- If missing, logs a warning and continues.
+
+This avoids hard failures on distros where a unit might not exist.
+
+### 8) Firewall setup
+
+Function: `setup_firewall()`
+
+- If `ufw` exists:
+  - sets defaults: deny incoming, allow outgoing
+  - allows OpenSSH
+  - enables UFW (`--force` to avoid prompts)
+- If `ufw` is missing:
+  - logs warning and skips.
+
+The `|| true` guards are used so non-critical firewall command issues won’t abort the entire provisioning run.
+
+### 9) Fail2ban setup
+
+Function: `setup_fail2ban()`
+
+- If `fail2ban-client` exists:
+  - enables/starts `fail2ban.service`.
+- Otherwise logs warning and skips.
+
+### 10) Main execution order
+
+Function: `main()`
+
+1. Log startup
+2. Detect package manager
+3. Install baseline packages
+4. Configure firewall
+5. Enable fail2ban
+6. Log completion and log file path
+
+Finally `main "$@"` executes the workflow.
+
+---
+
+## Expected result after successful run
+
+- Common admin/network utilities are installed.
+- Host firewall is active with conservative defaults and SSH allowed.
+- Brute-force protection service (`fail2ban`) is enabled when available.
+- Full execution log is stored at the configured `LOG_FILE` path.

--- a/scripts/setup-linux-auto.sh
+++ b/scripts/setup-linux-auto.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Automated Linux setup script (idempotent) for Debian/Ubuntu, Fedora, and Arch-based systems.
+# Run with: sudo ./scripts/setup-linux-auto.sh
+
+LOG_FILE="${LOG_FILE:-/var/log/linux-auto-setup.log}"
+PACKAGES=(
+  curl
+  wget
+  git
+  vim
+  htop
+  unzip
+  ca-certificates
+  gnupg
+  lsb-release
+  ufw
+  fail2ban
+)
+
+info() { printf '\n[INFO] %s\n' "$*"; }
+warn() { printf '\n[WARN] %s\n' "$*"; }
+
+if [[ "${EUID}" -ne 0 ]]; then
+  echo "Please run as root: sudo $0"
+  exit 1
+fi
+
+mkdir -p "$(dirname "$LOG_FILE")"
+touch "$LOG_FILE"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+detect_pm() {
+  if command -v apt-get >/dev/null 2>&1; then
+    echo apt
+  elif command -v dnf >/dev/null 2>&1; then
+    echo dnf
+  elif command -v pacman >/dev/null 2>&1; then
+    echo pacman
+  else
+    echo unknown
+  fi
+}
+
+install_packages() {
+  local pm="$1"
+  case "$pm" in
+    apt)
+      info "Updating apt cache..."
+      apt-get update
+      info "Installing packages with apt..."
+      DEBIAN_FRONTEND=noninteractive apt-get install -y "${PACKAGES[@]}"
+      ;;
+    dnf)
+      info "Installing packages with dnf..."
+      dnf install -y "${PACKAGES[@]}"
+      ;;
+    pacman)
+      info "Refreshing package database and installing packages with pacman..."
+      pacman -Sy --noconfirm --needed "${PACKAGES[@]}"
+      ;;
+    *)
+      warn "Unsupported package manager. Skipping package installation."
+      ;;
+  esac
+}
+
+enable_service_if_exists() {
+  local service="$1"
+  if systemctl list-unit-files | awk '{print $1}' | grep -Fxq "$service"; then
+    info "Enabling and starting $service"
+    systemctl enable --now "$service"
+  else
+    warn "Service $service not found. Skipping."
+  fi
+}
+
+setup_firewall() {
+  if command -v ufw >/dev/null 2>&1; then
+    info "Configuring UFW defaults..."
+    ufw default deny incoming || true
+    ufw default allow outgoing || true
+    ufw allow OpenSSH || true
+    ufw --force enable || true
+  else
+    warn "ufw not installed, skipping firewall setup."
+  fi
+}
+
+setup_fail2ban() {
+  if command -v fail2ban-client >/dev/null 2>&1; then
+    enable_service_if_exists fail2ban.service
+  else
+    warn "fail2ban not installed, skipping fail2ban setup."
+  fi
+}
+
+main() {
+  info "Starting Linux auto setup"
+
+  local pm
+  pm="$(detect_pm)"
+  info "Detected package manager: $pm"
+
+  install_packages "$pm"
+  setup_firewall
+  setup_fail2ban
+
+  info "Setup complete. Review logs at $LOG_FILE"
+}
+
+main "$@"


### PR DESCRIPTION
### Motivation

- Provide a clear, human-readable explanation of the automated Linux bootstrap workflow so operators can safely run and inspect it. 
- Deliver an idempotent, cross-distro setup script that documents default configuration and expected post-run state for Debian/Ubuntu, Fedora, and Arch-based systems. 
- Make it easy to override runtime behavior (for example `LOG_FILE`) and avoid surprising failures during provisioning.

### Description

- Add `scripts/setup-linux-auto.sh`, an idempotent bootstrap script that uses `set -euo pipefail`, writes logs to `LOG_FILE` (default `/var/log/linux-auto-setup.log`), and installs a baseline `PACKAGES` list. 
- Implement package manager detection in `detect_pm` and per-distro installers in `install_packages`, covering `apt`, `dnf`, and `pacman`. 
- Add helper functions `info`, `warn`, `enable_service_if_exists`, `setup_firewall`, `setup_fail2ban`, and a `main` entrypoint to enable/start services, configure `ufw`, and enable `fail2ban` when available. 
- Add `README.md` containing usage examples and a detailed line-by-line interpretation of the script and its expected outcomes.

### Testing

- Performed a syntax check with `bash -n scripts/setup-linux-auto.sh`, which completed successfully. 
- Confirmed the README and script files are present and readable (documentation generation/inspection steps executed without error).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fb5386d6483318d2ad433baee7a2d)