### PR TITLE
Add internal network scan report

### DIFF
--- a/internal-network-scan.md
+++ b/internal-network-scan.md
@@ -1,0 +1,36 @@
+# Internal Network Scan Report
+
+- **Date (UTC):** 2026-02-28 21:57:06Z
+- **Scanner host IP:** 172.31.1.18
+- **Method:** ICMP ping sweep of `172.31.1.0/24`, then TCP connect probes (`nc -z`) on selected common ports.
+
+## Live hosts discovered
+
+- `172.31.1.18`
+- `172.31.1.19`
+- `172.31.1.20`
+
+## Open ports (tested set)
+
+Tested ports: `22, 53, 80, 111, 443, 2375, 2376, 3306, 5432, 6379, 8080`
+
+- `172.31.1.18`: no open ports detected in tested set
+- `172.31.1.19`: `8080` open
+- `172.31.1.20`: no open ports detected in tested set
+
+## Commands used
+
+```bash
+hostname -I
+for i in $(seq 1 254); do
+  host=172.31.1.$i
+  ping -c 1 -W 1 "$host" >/dev/null 2>&1 && echo "$host"
+done
+
+for h in 172.31.1.18 172.31.1.19 172.31.1.20; do
+  for p in 22 53 80 111 443 2375 2376 3306 5432 6379 8080; do
+    nc -z -w 1 "$h" "$p" >/dev/null 2>&1 && echo "$h:$p"
+  done
+done
+```
+


### PR DESCRIPTION
### Motivation

- Capture and document a quick internal network discovery from the current environment to provide reproducible findings and context. 
- Provide a concise inventory of live hosts and common service ports for follow-up triage or auditing.

### Description

- Add `internal-network-scan.md` containing a UTC timestamp, scanner host IP, scan method, discovered live hosts, and open-port findings for the tested port set. 
- Include the exact shell commands used (ICMP ping sweep and `nc -z` TCP connect probes) so the scan can be reproduced.

### Testing

- Ran `hostname -I` which returned `172.31.1.18` and succeeded. 
- Performed an ICMP ping sweep loop over `172.31.1.0/24` which discovered `172.31.1.18`, `172.31.1.19`, and `172.31.1.20` and completed successfully. 
- Probed common ports with `nc -z` against the discovered hosts which detected port `8080` open on `172.31.1.19` and found no tested open ports on the other hosts, and the probes completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3645fe088832cae65c55da302a63e)