### PR TITLE
Add GitHub revenue tooling bootstrap script and Revenue Ops workflow

### DIFF
--- a/.github/workflows/revenue-ops.yml
+++ b/.github/workflows/revenue-ops.yml
@@ -1,0 +1,98 @@
+name: Revenue Ops Automation
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Target environment"
+        required: true
+        default: "production"
+        type: choice
+        options:
+          - production
+          - staging
+      run_settlement_reconciliation:
+        description: "Run settlement reconciliation checks"
+        required: true
+        default: true
+        type: boolean
+  schedule:
+    - cron: "15 * * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: revenue-ops-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  provider-health:
+    runs-on: ubuntu-latest
+    environment: ${{ github.event.inputs.environment || 'production' }}
+    steps:
+      - name: Validate required baseline configuration
+        run: |
+          missing=0
+          for var in BILLING_PROVIDER CRM_PROVIDER ANALYTICS_PROVIDER DEFAULT_CURRENCY; do
+            if [ -z "${!var}" ]; then
+              echo "Missing variable: $var"
+              missing=1
+            fi
+          done
+
+          if [ "$missing" -eq 1 ]; then
+            echo "One or more required variables are missing."
+            exit 1
+          fi
+
+          echo "Baseline configuration validated."
+        env:
+          BILLING_PROVIDER: ${{ vars.BILLING_PROVIDER }}
+          CRM_PROVIDER: ${{ vars.CRM_PROVIDER }}
+          ANALYTICS_PROVIDER: ${{ vars.ANALYTICS_PROVIDER }}
+          DEFAULT_CURRENCY: ${{ vars.DEFAULT_CURRENCY }}
+
+      - name: Stripe API health check (optional)
+        if: ${{ secrets.STRIPE_API_KEY != '' }}
+        run: |
+          curl -sS https://api.stripe.com/v1/balance \
+            -u "${STRIPE_API_KEY}:" > /tmp/stripe-response.json
+          test -s /tmp/stripe-response.json
+          echo "Stripe API responded successfully."
+        env:
+          STRIPE_API_KEY: ${{ secrets.STRIPE_API_KEY }}
+
+      - name: Paddle API health check (optional)
+        if: ${{ secrets.PADDLE_API_KEY != '' }}
+        run: |
+          status_code=$(curl -sS -o /tmp/paddle-response.json -w "%{http_code}" \
+            -H "Authorization: Bearer ${PADDLE_API_KEY}" \
+            https://api.paddle.com/notification-settings)
+
+          if [ "$status_code" -lt 200 ] || [ "$status_code" -ge 400 ]; then
+            echo "Paddle API check failed with status: $status_code"
+            exit 1
+          fi
+
+          echo "Paddle API responded successfully."
+        env:
+          PADDLE_API_KEY: ${{ secrets.PADDLE_API_KEY }}
+
+  settlement-reconciliation:
+    if: ${{ github.event_name == 'schedule' || github.event.inputs.run_settlement_reconciliation == 'true' }}
+    needs: provider-health
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate reconciliation summary
+        run: |
+          echo "Revenue settlement reconciliation stub"
+          echo "Date: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          echo "Billing provider: ${BILLING_PROVIDER}"
+          echo "Default currency: ${DEFAULT_CURRENCY}"
+          echo "Threshold alert: ${REVENUE_ALERT_THRESHOLD:-not-set}"
+          echo "Integrate your finance data pull script here."
+        env:
+          BILLING_PROVIDER: ${{ vars.BILLING_PROVIDER }}
+          DEFAULT_CURRENCY: ${{ vars.DEFAULT_CURRENCY }}
+          REVENUE_ALERT_THRESHOLD: ${{ vars.REVENUE_ALERT_THRESHOLD }}

--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ chmod +x setup.sh
 - Terraform
 - kubectl
 
+
+## Revenue Tooling Automation
+
+Use `scripts/configure-revenue-tools.sh` to provision revenue/CRM/analytics secrets and variables in a target GitHub repository, then run `.github/workflows/revenue-ops.yml` for scheduled health checks and reconciliation scaffolding. See `REVENUE_TOOLING_SETUP.md`.
+
 ## Customization
 
 Edit `config/packages.txt` to add or remove packages.

--- a/REVENUE_TOOLING_SETUP.md
+++ b/REVENUE_TOOLING_SETUP.md
@@ -1,0 +1,68 @@
+# Revenue Tooling Setup (GitHub-Driven)
+
+This repository now includes a production-oriented setup pattern to automate revenue tooling checks through GitHub Actions.
+
+## What was added
+
+- `scripts/configure-revenue-tools.sh`: One-command bootstrap to configure repo secrets and variables via GitHub CLI.
+- `.github/workflows/revenue-ops.yml`: Scheduled + on-demand workflow for provider health and reconciliation stubs.
+
+## 1) Authenticate GitHub CLI
+
+```bash
+gh auth login
+```
+
+## 2) Export configuration values locally
+
+Set only the providers you actually use.
+
+```bash
+# Sensitive secrets
+export STRIPE_API_KEY="sk_live_..."
+export STRIPE_WEBHOOK_SECRET="whsec_..."
+export PADDLE_API_KEY="pdl_live_..."
+export GUMROAD_ACCESS_TOKEN="..."
+export SHOPIFY_ADMIN_API_TOKEN="..."
+export HUBSPOT_API_KEY="..."
+export POSTHOG_API_KEY="..."
+export SLACK_WEBHOOK_URL="https://hooks.slack.com/services/..."
+
+# Non-sensitive variables
+export BILLING_PROVIDER="stripe"
+export BILLING_ENVIRONMENT="production"
+export CRM_PROVIDER="hubspot"
+export ANALYTICS_PROVIDER="posthog"
+export DEFAULT_CURRENCY="USD"
+export REVENUE_ALERT_THRESHOLD="1000"
+```
+
+## 3) Apply configuration to your target repository
+
+```bash
+./scripts/configure-revenue-tools.sh <owner/repo>
+```
+
+Example:
+
+```bash
+./scripts/configure-revenue-tools.sh cashpilotthrive-hue/my-saas-repo
+```
+
+## 4) Run automation
+
+In GitHub, go to **Actions → Revenue Ops Automation → Run workflow** and choose `production` or `staging`.
+
+## Professional methodology baked into this setup
+
+- **Least privilege by default**: workflow uses read-only repository permissions.
+- **Idempotent config**: setup script only applies values present in your shell.
+- **Controlled execution**: hourly schedule + manual dispatch for operational flexibility.
+- **Environment separation**: workflow uses environment-scoped execution.
+- **Progressive integration**: provider checks are optional and activate only if secrets are configured.
+
+## Recommended next steps
+
+- Add your own reconciliation script in `settlement-reconciliation` job.
+- Add alerting action for failed health checks.
+- Store audit artifacts (daily summaries) using workflow artifacts.

--- a/scripts/configure-revenue-tools.sh
+++ b/scripts/configure-revenue-tools.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO="${1:-}"
+
+if [[ -z "$REPO" ]]; then
+  echo "Usage: $0 <owner/repo>"
+  echo "Example: $0 cashpilotthrive-hue/my-saas-repo"
+  exit 1
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "Error: GitHub CLI (gh) is required. Install gh and authenticate first."
+  exit 1
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+  echo "Error: gh is not authenticated. Run: gh auth login"
+  exit 1
+fi
+
+set_secret_if_present() {
+  local secret_name="$1"
+  local value="${!secret_name:-}"
+
+  if [[ -n "$value" ]]; then
+    printf '%s' "$value" | gh secret set "$secret_name" --repo "$REPO"
+    echo "✓ Set secret: $secret_name"
+  else
+    echo "- Skipped secret: $secret_name (env var not provided)"
+  fi
+}
+
+set_var_if_present() {
+  local var_name="$1"
+  local value="${!var_name:-}"
+
+  if [[ -n "$value" ]]; then
+    gh variable set "$var_name" --body "$value" --repo "$REPO"
+    echo "✓ Set variable: $var_name"
+  else
+    echo "- Skipped variable: $var_name (env var not provided)"
+  fi
+}
+
+echo "Configuring revenue tooling for $REPO"
+
+echo "Setting provider secrets (if available in your shell environment)..."
+set_secret_if_present STRIPE_API_KEY
+set_secret_if_present STRIPE_WEBHOOK_SECRET
+set_secret_if_present PADDLE_API_KEY
+set_secret_if_present GUMROAD_ACCESS_TOKEN
+set_secret_if_present SHOPIFY_ADMIN_API_TOKEN
+set_secret_if_present HUBSPOT_API_KEY
+set_secret_if_present POSTHOG_API_KEY
+set_secret_if_present SLACK_WEBHOOK_URL
+
+echo "Setting non-sensitive configuration variables..."
+set_var_if_present BILLING_PROVIDER
+set_var_if_present BILLING_ENVIRONMENT
+set_var_if_present CRM_PROVIDER
+set_var_if_present ANALYTICS_PROVIDER
+set_var_if_present DEFAULT_CURRENCY
+set_var_if_present REVENUE_ALERT_THRESHOLD
+
+echo "Done."
+echo "Next: run the workflow '.github/workflows/revenue-ops.yml' from the Actions tab."


### PR DESCRIPTION
### Motivation
- Provide an automated, idempotent way to provision revenue/CRM/analytics secrets and configuration to a target GitHub repository. 
- Add scheduled and on-demand operational checks for payment/analytics providers and a reconciliation scaffold to support production revenue operations. 
- Surface a clear, professional setup and rollout guide so repository owners can safely integrate real provider credentials and run the automation. 

### Description
- Add `scripts/configure-revenue-tools.sh`, a `gh`-based bootstrap that sets repository secrets and variables only when corresponding environment variables are present. 
- Add `.github/workflows/revenue-ops.yml`, a workflow with `provider-health` and `settlement-reconciliation` jobs that run hourly and via manual dispatch, perform baseline variable validation, and optionally check Stripe and Paddle when secrets exist. 
- Add `REVENUE_TOOLING_SETUP.md` with authentication, export, apply, and operational guidance and best-practice notes (least-privilege, idempotency, environment separation). 
- Update `README.md` to reference the new revenue tooling automation and point to the setup guide. 

### Testing
- Verified shell script syntax for all scripts with `bash -n setup.sh` and `for script in scripts/*.sh; do bash -n "$script"; done`, which completed successfully. 
- Validated the workflow YAML by loading it with Ruby (`YAML.load_file`) which reported `workflow yaml ok`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa1be5fd50832cb4fd29b9d8a6cea5)