### PR TITLE
Add secure helper for Agentverse chat-agent registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,17 @@ This project is licensed under the MIT License. See `LICENSE` for details.
 ---
 
 Thank you for exploring AFS — where finance meets the future, autonomously.
+
+---
+
+## 🔌 Optional: Register a Chat Agent
+
+If you want to register a chat agent endpoint, use environment variables for secrets (never hardcode API keys in source files):
+
+```bash
+export AGENTVERSE_KEY="your-agentverse-api-key"
+export AGENT_SEED_PHRASE="your-agent-seed-phrase"
+python register_chat_agent.py
+```
+
+This repository includes `register_chat_agent.py` as a safe helper script that reads credentials from your environment.

--- a/register_chat_agent.py
+++ b/register_chat_agent.py
@@ -1,0 +1,40 @@
+"""Register a chat agent with Agentverse using environment variables.
+
+Usage:
+    export AGENTVERSE_KEY="..."
+    export AGENT_SEED_PHRASE="..."
+    python register_chat_agent.py
+"""
+
+import os
+
+from uagents_core.utils.registration import (
+    RegistrationRequestCredentials,
+    register_chat_agent,
+)
+
+
+def _required_env(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        raise RuntimeError(
+            f"Missing required environment variable: {name}. "
+            "Set it before running this script."
+        )
+    return value
+
+
+def main() -> None:
+    register_chat_agent(
+        "ChatG",
+        "https://chatgpt.com/codex/cloud",
+        active=True,
+        credentials=RegistrationRequestCredentials(
+            agentverse_api_key=_required_env("AGENTVERSE_KEY"),
+            agent_seed_phrase=_required_env("AGENT_SEED_PHRASE"),
+        ),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 # AFS Dependencies
+uagents-core


### PR DESCRIPTION
### Motivation
- Provide a small, safe CLI helper to register a chat agent without embedding secrets in source code. 
- Ensure the project lists the dependency required to import the registration utilities. 

### Description
- Add `register_chat_agent.py` which validates `AGENTVERSE_KEY` and `AGENT_SEED_PHRASE` from the environment via `_required_env` and calls `register_chat_agent` with `RegistrationRequestCredentials`.
- Update `README.md` with an "Optional: Register a Chat Agent" section that documents using environment variables and running `python register_chat_agent.py`.
- Add `uagents-core` to `requirements.txt` so the registration helper can import the necessary module. 

### Testing
- Compiled the new and existing scripts with `python -m py_compile register_chat_agent.py run_afs.py` and the compilation succeeded. 
- No other automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db8227b0608331a2c11c09a61eb0ed)