### PR TITLE
Add chat agent registration script and README instructions; add uagents-core dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,26 @@ This project is licensed under the MIT License. See `LICENSE` for details.
 ---
 
 Thank you for exploring AFS — where finance meets the future, autonomously.
+
+---
+
+## 🔌 Optional: Register a Chat Agent
+
+If you want to register a chat agent endpoint, use environment variables for secrets (never hardcode API keys in source files):
+
+```bash
+export AGENTVERSE_KEY="your-agentverse-api-key"
+export AGENT_SEED_PHRASE="your-agent-seed-phrase"
+export AGENT_ENDPOINT="https://your-agent-host.example/chat"
+export AGENT_NAME="ChatG"  # optional; defaults to ChatG
+python register_chat_agent.py
+```
+
+This repository includes `register_chat_agent.py` as a helper script that validates required environment variables and then registers the agent.
+
+### Token safety checklist
+
+- Treat JWT/API keys as secrets.
+- Revoke and rotate any token that was pasted into chat, logs, commits, or screenshots.
+- Use short-lived credentials where possible.
+- Keep `.env` files out of version control.

--- a/register_chat_agent.py
+++ b/register_chat_agent.py
@@ -1,0 +1,53 @@
+"""Register a chat agent with Agentverse using environment variables.
+
+Required:
+    AGENTVERSE_KEY
+    AGENT_SEED_PHRASE
+    AGENT_ENDPOINT
+
+Optional:
+    AGENT_NAME (default: ChatG)
+
+Usage:
+    export AGENTVERSE_KEY="..."
+    export AGENT_SEED_PHRASE="..."
+    export AGENT_ENDPOINT="https://your-agent-host.example/chat"
+    export AGENT_NAME="ChatG"
+    python register_chat_agent.py
+"""
+
+import os
+
+from uagents_core.utils.registration import (
+    RegistrationRequestCredentials,
+    register_chat_agent,
+)
+
+
+def _required_env(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        raise RuntimeError(
+            f"Missing required environment variable: {name}. "
+            "Set it before running this script."
+        )
+    return value
+
+
+def main() -> None:
+    agent_name = os.getenv("AGENT_NAME", "ChatG")
+    endpoint = _required_env("AGENT_ENDPOINT")
+
+    register_chat_agent(
+        agent_name,
+        endpoint,
+        active=True,
+        credentials=RegistrationRequestCredentials(
+            agentverse_api_key=_required_env("AGENTVERSE_KEY"),
+            agent_seed_phrase=_required_env("AGENT_SEED_PHRASE"),
+        ),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 # AFS Dependencies
+uagents-core


### PR DESCRIPTION
### Motivation
- Provide a simple, repeatable way to register a chat agent endpoint with Agentverse using environment variables and avoid hardcoding secrets. 
- Document the optional integration and cover token safety best practices so contributors can safely register agents. 

### Description
- Add `register_chat_agent.py`, a small helper that validates `AGENTVERSE_KEY`, `AGENT_SEED_PHRASE`, and `AGENT_ENDPOINT` environment variables and calls `register_chat_agent` with `RegistrationRequestCredentials`.
- Update `README.md` with usage instructions showing how to set `AGENTVERSE_KEY`, `AGENT_SEED_PHRASE`, `AGENT_ENDPOINT`, and optional `AGENT_NAME`, plus a token safety checklist. 
- Add `uagents-core` to `requirements.txt` as a runtime dependency required by the registration helper. 

### Testing
- No automated tests were added or modified for this change. 
- No automated test runs were performed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db8227b0608331a2c11c09a61eb0ed)