### PR TITLE
Add explicit moderation restriction status

### DIFF
--- a/safe-assistant-app/README.md
+++ b/safe-assistant-app/README.md
@@ -34,5 +34,6 @@ Browse to `http://localhost:4173`.
 ## Notes
 
 - This is a local demo with in-memory storage (non-persistent).
+- The `/moderate` response includes `restriction` (`none` or `blocked`) plus matched `categories`.
 - Replace in-memory stores with a database and managed object storage for production.
 - Add proper authentication + role-based authorization for real deployments.

--- a/safe-assistant-app/backend/app.py
+++ b/safe-assistant-app/backend/app.py
@@ -58,6 +58,7 @@ class ModerationRequest(BaseModel):
 class ModerationResponse(BaseModel):
     flagged: bool
     categories: list[str]
+    restriction: str
 
 
 class ToolRunRequest(BaseModel):
@@ -95,8 +96,9 @@ def health() -> dict[str, str]:
 @app.post("/moderate", response_model=ModerationResponse)
 def moderate(payload: ModerationRequest) -> ModerationResponse:
     lowered = payload.content.lower()
-    hits = [term for term in SAFE_BLOCKLIST if term in lowered]
-    return ModerationResponse(flagged=bool(hits), categories=hits)
+    hits = sorted(term for term in SAFE_BLOCKLIST if term in lowered)
+    restriction = "blocked" if hits else "none"
+    return ModerationResponse(flagged=bool(hits), categories=hits, restriction=restriction)
 
 
 @app.post("/chat", response_model=ChatResponse)

--- a/safe-assistant-app/backend/requirements.txt
+++ b/safe-assistant-app/backend/requirements.txt
@@ -2,3 +2,4 @@ fastapi==0.116.1
 uvicorn==0.35.0
 python-multipart==0.0.20
 pydantic==2.11.7
+httpx==0.28.1

--- a/safe-assistant-app/tests/test_api.py
+++ b/safe-assistant-app/tests/test_api.py
@@ -47,3 +47,12 @@ def test_chat_safe():
     assert r.status_code == 200
     payload = r.json()
     assert 'Safe Omni Assistant response' in payload['content']
+
+
+def test_moderation_reports_no_restrictions_for_safe_content():
+    r = client.post('/moderate', json={'content': 'Tell me a joke about cats'})
+    assert r.status_code == 200
+    payload = r.json()
+    assert payload['flagged'] is False
+    assert payload['categories'] == []
+    assert payload['restriction'] == 'none'


### PR DESCRIPTION
### Motivation
- Make the moderation API return an explicit, machine-friendly restriction status so clients can easily distinguish blocked vs safe results.
- Ensure moderation category matches are deterministic to avoid non-deterministic responses across runs.
- Make tests runnable in fresh environments by including the dependency required by `fastapi.testclient`.

### Description
- Added a `restriction: str` field to `ModerationResponse` and return `"blocked"` when matches exist or `"none"` otherwise in `safe-assistant-app/backend/app.py`.
- Made matched blocklist terms deterministic by sorting `hits` before returning them in the moderation response.
- Added a new test `test_moderation_reports_no_restrictions_for_safe_content` to `safe-assistant-app/tests/test_api.py` to assert safe content yields `flagged: false`, empty `categories`, and `restriction: "none"`.
- Updated `safe-assistant-app/backend/requirements.txt` to include `httpx==0.28.1` and documented the new `restriction` field in `safe-assistant-app/README.md`.

### Testing
- Attempted `pytest -q safe-assistant-app/tests/test_api.py` which initially failed due to missing `httpx` (error raised by `starlette.testclient`).
- Installed backend dependencies with `pip install -r safe-assistant-app/backend/requirements.txt` which installed `httpx` successfully.
- Ran `PYTHONPATH=safe-assistant-app pytest -q safe-assistant-app/tests/test_api.py` and all tests passed (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee204523ec8331aa6dbee7e44d9277)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README to clarify the moderation response structure, including the restriction status field.

* **Improvements**
  * Moderation API now returns a `restriction` status indicator ("blocked" for unsafe content, "none" for safe content).
  * Categories in responses are now deterministically sorted for consistency.

* **Tests**
  * Added test coverage for safe content moderation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->